### PR TITLE
Update expected results of change context in which function is called

### DIFF
--- a/tests/app/functions.js
+++ b/tests/app/functions.js
@@ -21,7 +21,7 @@ define([ 'use!underscore' ], function(_) {
 
       // define a function for fn that calls the speak function such that the
       // following test will pass
-      expect(fn()).to.be('Hello, Rebecca!');
+      expect(fn()).to.be('Hello, Rebecca!!!');
     });
 
     it("you should be able to return a function from a function", function() {


### PR DESCRIPTION
updating expected results of 'change the context in which a function is called' as speak appends three exclamation marks but the test expects only one.
