### PR TITLE
Add test for currying existing functions

### DIFF
--- a/tests/app/functions.js
+++ b/tests/app/functions.js
@@ -97,7 +97,7 @@ define([ 'use!underscore' ], function(_) {
       expect(fn(curryMe, a, b, c)()).to.be(curryMe(a, b, c));
       expect(fn(curryMe, a, b, c)()).to.be(curryMe(a, b, c));
       expect(fn(curryMe, b, a, c)()).to.be(curryMe(b, a, c));
-      expect(fn(curryMe)(b)(a)(c) ).to.be(curryMe(b, a, c));
+      expect(fn(curryMe)(b)(a)(c)).to.be(curryMe(b, a, c));
     });
 
     it('you should be able to use closures', function () {


### PR DESCRIPTION
Hey, sweet project.

While fiddling around with the tests, I found myself at the part where I should be willing and able to curry functions.

My initial stab was simply a partially applied function. Which made the tests pass.
Albeit having zero theoretical knowledge about currying functions, I remembered from somewhere that they are not simply partial functions. And that you should be able to do something of the following: 

```
var fn = function ( n1, n2, n3, n4 ) { return n1+n2+n3+n4 };
var curried = curry( fn ); 
curried( 1 )( 2 )( 3 )( 4 ); // 10
fn( 1, 2, 3, 4 ); // 10
```
