### PR TITLE
Re-expose doSomeStuff to the makeClosures answer function

### DIFF
--- a/tests/app/functions.js
+++ b/tests/app/functions.js
@@ -104,7 +104,7 @@ define([
 
       doSomeStuff = function (x) { return x * x; };
 
-      var funcs = answers.makeClosures(arr);
+      var funcs = answers.makeClosures(arr, doSomeStuff);
       expect(funcs).to.have.length(arr.length);
 
       _.each(funcs, function(func, i) {


### PR DESCRIPTION
I could be wrong, but the closures test looks like it originally worked in part because the solution function was being defined as a sibling of doSomeStuff; since the function answers were moved to a new file/object in b42191563c, I don't see any way to solve this problem without passing the doSomeStuff function into makeClosures along with the array of data.
