### PR TITLE
move tests to separate it blocks for clarity

### DIFF
--- a/app/flowControl.js
+++ b/app/flowControl.js
@@ -10,13 +10,5 @@ define([ 'use!underscore' ], function(_) {
       // 'fizzbuzz';
       // otherwise the function should return the number
     },
-
-    or : function(a, b) {
-
-    },
-
-    and : function(a, b) {
-
-    }
   };
 });

--- a/app/logicalOperators.js
+++ b/app/logicalOperators.js
@@ -1,0 +1,13 @@
+if (typeof define !== 'function') { var define = require('amdefine')(module); }
+
+define([ 'use!underscore' ], function(_) {
+  return {
+    or : function(a, b) {
+
+    },
+
+    and : function(a, b) {
+
+    }
+  };
+});

--- a/tests/app/flowControl.js
+++ b/tests/app/flowControl.js
@@ -14,16 +14,5 @@ define([
       expect(answers.fizzBuzz(5)).to.be('buzz');
       expect(answers.fizzBuzz(num * 3 * 5)).to.be('fizzbuzz');
     });
-
-    it("you should be able to work with logical operators", function() {
-      expect(answers.and(false, false)).not.to.be.ok();
-      expect(answers.and(true, false)).not.to.be.ok();
-      expect(answers.and(true, true)).to.be.ok();
-
-      expect(answers.or(true, false)).to.be.ok();
-      expect(answers.or(true, true)).to.be.ok();
-      expect(answers.or(false, false)).not.to.be.ok();
-    });
   });
-
 });

--- a/tests/app/logicalOperators.js
+++ b/tests/app/logicalOperators.js
@@ -1,0 +1,20 @@
+if (typeof define !== 'function') { var define = require('amdefine')(module); }
+if (typeof expect !== 'function') { var expect = require('expect.js'); }
+
+define([
+  'app/logicalOperators'
+], function(answers) {  
+  describe("logial operators", function(){ 
+    it("you should be able to work with logical or", function() {
+      expect(answers.and(false, false)).not.to.be.ok();
+      expect(answers.and(true, false)).not.to.be.ok();
+      expect(answers.and(true, true)).to.be.ok();
+    });
+    
+    it("you should be able to work with logical and", function() {
+      expect(answers.or(true, false)).to.be.ok();
+      expect(answers.or(true, true)).to.be.ok();
+      expect(answers.or(false, false)).not.to.be.ok();
+    });
+  });
+});

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -4,7 +4,8 @@ var tests = [
   'tests/app/objects',
   'tests/app/functions',
   'tests/app/modules',
-  'tests/app/flowControl'
+  'tests/app/flowControl',
+  'tests/app/logicalOperators'
 ];
 
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
The rest of the tests have one it per function written. This it tested two separate functions. It is clearer to restrict all tests in the it to a single function.

While I was at that, it made sense to separate logical functions from flow control. 
