### PR TITLE
this test was passing incorrectly

### DIFF
--- a/tests/app/functions.js
+++ b/tests/app/functions.js
@@ -107,9 +107,9 @@ define([
       var funcs = answers.makeClosures(arr, doSomeStuff);
       expect(funcs).to.have.length(arr.length);
 
-      _.each(funcs, function(func, i) {
+      for(var i = 0; i< arr.length; i++) {
         expect(funcs[i]()).to.be(doSomeStuff(arr[i]));
-      });
+      };
     });
   });
 });


### PR DESCRIPTION
with the implementation 
    makeClosures : function(array,doSomeStuff) {
          return(function(a,b,c,d){});
    }

That implementation was correctly makes the first assertion pass, but does not exercise the second.
