### PR TITLE
Match stub function definitions in /app with args from /tests/app

### DIFF
--- a/app/async.js
+++ b/app/async.js
@@ -4,7 +4,7 @@ define(function() {
 
     },
 
-    manipulateRemoteData : function() {
+    manipulateRemoteData : function(url) {
 
     }
   };

--- a/app/functions.js
+++ b/app/functions.js
@@ -10,11 +10,11 @@ define(function() {
 
     },
 
-    functionFunction : function() {
+    functionFunction : function(str) {
 
     },
 
-    partial : function() {
+    partial : function(fn, str1, str2) {
 
     },
 
@@ -22,15 +22,15 @@ define(function() {
 
     },
 
-    callIt : function() {
+    callIt : function(fn) {
 
     },
 
-    curryIt : function() {
+    curryIt : function(fn) {
 
     },
 
-    makeClosures : function() {
+    makeClosures : function(arr, fn) {
 
     }
   };

--- a/app/modules.js
+++ b/app/modules.js
@@ -2,7 +2,7 @@ if (typeof define !== 'function') { var define = require('amdefine')(module); }
 
 define(function() {
   return {
-    createModule : function() {
+    createModule : function(str1, str2) {
 
     }
   };


### PR DESCRIPTION
Based on the discussion of Issue #19, I feel it makes the tests more user-friendly to have the arguments in the stub functions match those in the tests—particularly in cases (such as curryIt or useArguments) where specifying the arguments exactly as the function is referenced within the tests file would not be appropriate.
