### PR TITLE
jQuery not listed as available

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ the `data` directory; you can access it at `/data/<filename>.json`.
 
 ### Available dependencies
 
-The repo includes Backbone, Underscore, and RequireJS. If there's other stuff
-you'd find useful, you can put it in the `lib` directory.
+The repo includes jQuery, Backbone, Underscore, and RequireJS. If there's other
+stuff you'd find useful, you can put it in the `lib` directory.
 
 ## I want to see the answers!
 
@@ -91,4 +91,3 @@ purposes under the following conditions:
 
 Any of these conditions can be waived if you get permission from the copyright
 holder.
-


### PR DESCRIPTION
I guess, in retrospect, it's implicit, but I just spent 10 minutes trying to work out how to use XMLHttpRequest before noticing that jQuery was included, hence the ridiculous patch.
