### PR TITLE
Clarify arrays.remove test case

### DIFF
--- a/tests/app/arrays.js
+++ b/tests/app/arrays.js
@@ -19,7 +19,8 @@ define([
       expect(answers.sum(a)).to.be(10);
     });
 
-    it("you should be able to remove an item from an array", function() {
+    it("you should be able to remove a value from an array", function() {
+      a.push(2); // Make sure the value appears more than one time
       var result = answers.remove(a, 2);
 
       expect(result).to.have.length(3);


### PR DESCRIPTION
According to my understanding, the second argument to `arrays.remove` is a value, not an index. The proposed change clarifies this meaning (in the description) and makes sure that the implementation removes all occurrences of the value from the array.

Since the test case is ambigous both in description and in code, we might as well clarify to request the opposite behavior, i. e. removing only the first occurence of the value. In any way, the test case should settle on either of both possible functionalities.
