### PR TITLE
Unify answer templates

### DIFF
--- a/app/async.js
+++ b/app/async.js
@@ -1,3 +1,5 @@
+if (typeof define !== 'function') { var define = require('amdefine')(module); }
+
 define(function() {
   return {
     async : function() {

--- a/app/flowControl.js
+++ b/app/flowControl.js
@@ -1,6 +1,6 @@
 if (typeof define !== 'function') { var define = require('amdefine')(module); }
 
-define([ 'use!underscore' ], function(_) {
+define(function() {
   return {
     fizzBuzz : function(num) {
       // write a function that receives a number as its argument;

--- a/app/logicalOperators.js
+++ b/app/logicalOperators.js
@@ -1,6 +1,6 @@
 if (typeof define !== 'function') { var define = require('amdefine')(module); }
 
-define([ 'use!underscore' ], function(_) {
+define(function() {
   return {
     or : function(a, b) {
 


### PR DESCRIPTION
- Include `define` definition everywhere
- Do not require underscore
