### PR TITLE
Clarify modules test

### DIFF
--- a/tests/app/modules.js
+++ b/tests/app/modules.js
@@ -8,10 +8,16 @@ define([
     it("you should be able to create a function that returns a module", function() {
       var module = answers.createModule('hello', 'matt');
 
-      expect(module.name).to.be.ok();
-      expect(module.greeting).to.be.ok();
       expect(module.sayIt).to.be.a('function');
+      expect(module.name).to.be.ok('matt');
+      expect(module.greeting).to.be.ok('hello');
       expect(module.sayIt()).to.be('hello, matt');
+
+      module.name = 'katniss';
+      module.greeting = 'hi';
+      expect(module.name).to.be.ok('katniss');
+      expect(module.greeting).to.be.ok('hi');
+      expect(module.sayIt()).to.be('hi, katniss');
     });
   });
 });


### PR DESCRIPTION
The `modules.createModule` test did not fail on solutions which I understand as not correct ([1](https://github.com/sylvaingi/js-assessment/blob/15deb94ecba322e42bcb94e650e3acc79547ef2a/app/modules.js), [2](https://github.com/jonkemp/js-assessment/blob/answers/app/modules.js), [3](https://github.com/prodaea/js-assessment/blob/6b2d41c596efe5dfd5da0404ef9037f5f0a1da3a/app/modules.js)). This patch requires correct `module.greeting` and `module.name` values and the possibility to change those on the live object with correctly altered `sayIt` behavior.
