### PR TITLE
Adds test to check for sending NaN to flow control

### DIFF
--- a/tests/app/flowControl.js
+++ b/tests/app/flowControl.js
@@ -13,6 +13,7 @@ define([
       }
 
       expect(answers.fizzBuzz()).not.to.be.ok;
+      expect(answers.fizzBuzz('foo')).not.to.be.ok;
       expect(answers.fizzBuzz(2)).to.eql(2);
       expect(answers.fizzBuzz(101)).to.eql(101);
 


### PR DESCRIPTION
The comments in the flow control module said if no number was provided to return false and while there is a test for not sending a value, there was no test for returning a value that is NaN.
