### PR TITLE
tests/arrays: Assert that result does not equal original.

### DIFF
--- a/tests/app/arrays.js
+++ b/tests/app/arrays.js
@@ -27,6 +27,9 @@ define([
 
       expect(result).to.have.length(3);
       expect(result.join(' ')).to.eql('1 3 4');
+
+      // make sure that you didn't change the original array instance
+      expect(result).not.to.equal(a);
     });
 
     it('you should be able to remove a value from an array, returning the original array', function() {


### PR DESCRIPTION
Without this assertion, the simple implementation (where there is no copy being made) will pass for both `remove` and `removeWithoutCopy`.
