### PR TITLE
Updated styling of stats bar to handle scrolling on smaller window sizes...

### DIFF
--- a/tests/libs/mocha.css
+++ b/tests/libs/mocha.css
@@ -152,6 +152,7 @@ body {
 
 #mocha ul#stats {
   position: fixed;
+  z-index: 1;
   top: 15px;
   right: 10px;
   background: #fff;


### PR DESCRIPTION
Styling of stats bar so it's visible and can be clearly read if you have the window at less than 1175 px (in situations where you may have inspector open in one window next to the mocha tests window).
