### PR TITLE
count.js grunt lint fixes:

### DIFF
--- a/tests/app/count.js
+++ b/tests/app/count.js
@@ -1,4 +1,5 @@
-/*globals describe:true, it:true, expect:true, beforeEach:true */
+/*jshint expr:true */
+/*globals describe:true, it:true, expect:true, beforeEach:true, console:true */
 if (typeof define !== 'function') { var define = require('amdefine')(module); }
 if (typeof expect !== 'function') { var expect = require('expect.js'); }
 


### PR DESCRIPTION
``` bash
$ git checkout master
Already on 'master'

$ grunt
Running "jshint:all" (jshint) task
Linting tests/app/count.js...ERROR
[L21:C9] Read only.
        console = {};
[L34:C39] Expected an assignment or function call and instead saw an expression.
        expect(nums.length > 1).to.be.ok;
[L35:C39] Expected an assignment or function call and instead saw an expression.
        expect(nums.length < 5).to.be.ok;
[L53:C39] Expected an assignment or function call and instead saw an expression.
        expect(nums.length < 5).to.be.ok;

Warning: Task "jshint:all" failed. Use --force to continue.

Aborted due to warnings.

$ git checkout jshints
Switched to branch 'jshints'

$ grunt
Running "jshint:all" (jshint) task
>> 26 files lint free.

Done, without errors.
```
