### PR TITLE
Clarified ambiguous test wording for arrays.js remove per issue #80

### DIFF
--- a/tests/app/arrays.js
+++ b/tests/app/arrays.js
@@ -21,7 +21,7 @@ define([
       expect(answers.sum(a)).to.eql(10);
     });
 
-    it('you should be able to remove a value from an array', function() {
+    it('you should be able to remove all instances of a value from an array', function() {
       a.push(2); // Make sure the value appears more than one time
       var result = answers.remove(a, 2);
 
@@ -29,7 +29,7 @@ define([
       expect(result.join(' ')).to.eql('1 3 4');
     });
 
-    it('you should be able to remove a value from an array, returning the original array', function() {
+    it('you should be able to remove all instances of a value from an array, returning the original array', function() {
       a.splice( 1, 0, 2 );
       a.push( 2 );
       a.push( 2 );


### PR DESCRIPTION
Clarifies ambiguous test wording for remove and removeWithoutCopy functions on whether to remove a single instance or all instances of a given value per Open Issue #80.

Before, wording was unclear in arrays.js tests for remove and removeWithoutCopy that the intent is not to remove a specific value, or a single instance of an value, but rather all instances of a value from an array. Now, it clearly states all instances.