### PR TITLE
Catch array count solution using [].reduce with missing initialvalue

### DIFF
--- a/tests/app/arrays.js
+++ b/tests/app/arrays.js
@@ -87,9 +87,9 @@ define([
     });
 
     it('you should be able to count the occurences of an item in an array', function() {
-      var result = answers.count([ 1, 1, 1, 2, 1, 3 ], 1);
+      var result = answers.count([ 1, 2, 4, 4, 3, 4, 3 ], 4);
 
-      expect(result).to.eql(4);
+      expect(result).to.eql(3);
     });
 
     it('you should be able to find duplicates in an array', function() {


### PR DESCRIPTION
The test array used for the array count test does not catch an implementation solution that use Array.prototype.reduce() with missing initial value.

That is, this (wrong) solution pass the test:

``` js
count : function(arr, item) {
  return arr.reduce(function(prev, curr) {
    return curr === item ? prev + 1 : prev;
  });
}
```

By updating the test array the above fails the test as expected. By adding 0 as the initial value it will pass with the updated test array. (No changes needed to the js-assessment-answers implementation.)
