### PR TITLE
Replace console.log after modifying it for count test

### DIFF
--- a/tests/app/count.js
+++ b/tests/app/count.js
@@ -12,19 +12,27 @@ define([
    * number to the end number, one number per 1/10th of a second. The function should
    * return an object with a cancel method, which should cancel the counting.
    */
+  'use strict';
+
   describe('counter', function () {
-    var nums;
+    var nums, origConsoleLog;
 
     beforeEach(function () {
       nums = [];
 
       if (typeof console === 'undefined') {
-        console = {};
+        console = {
+          log: undefined,
+        };
       }
-
+      origConsoleLog = console.log;
       console.log = function (val) {
         nums.push(val);
       };
+    });
+
+    afterEach(function () {
+      console.log = origConsoleLog;
     });
 
     it('should count from start number to end number, one per 1/10th of a second', function (done) {


### PR DESCRIPTION
I noticed that when I was working on the answer for async, I wasn't able to use console.log to peek at things.  I took it as an opportunity to get more familiar with my JavaScript debugger.

This pull request assumes that count.js leaves console.log set to a tests/app/count.js-specific callback on accident, not to provide more of a challenge to folks implementing other tests.

After applying these changes, console.log once again works in my async answer.