### PR TITLE
Added hasOwnProperty test for when object has a similarly named property.

### DIFF
--- a/app/objects.js
+++ b/app/objects.js
@@ -12,6 +12,10 @@ define(function() {
 
     iterate : function(obj) {
 
+    },
+
+    iterate2 : function(obj) {
+
     }
   };
 });

--- a/tests/app/objects.js
+++ b/tests/app/objects.js
@@ -60,5 +60,20 @@ define([
 
       expect(answers.iterate(obj)).to.eql([ 'foo: bar', 'baz: bim' ]);
     });
+
+    it('you should be able to iterate over an object\'s "own" properties', function() {
+      // define a function for fn so that the following will pass
+      var C = function() {
+        this.foo = 'bar';
+        this.baz = 'bim';
+        this.hasOwnProperty = 'devious';
+      };
+
+      C.prototype.bop = 'bip';
+
+      var obj = new C();
+
+      expect(answers.iterate2(obj)).to.eql([ 'foo: bar', 'baz: bim', 'hasOwnProperty: devious' ]);
+    });
   });
 });


### PR DESCRIPTION
hasOwnProperty is not a reserved word, so you can have objects with properties called this.  If that is the case then to list the properties of an object you must use the syntax:

({}).hasOwnProperty.call(obj, prop)