### PR TITLE
Test cases are fixed for npm test.

### DIFF
--- a/tests/app/bestPractices.js
+++ b/tests/app/bestPractices.js
@@ -6,10 +6,14 @@ if (typeof expect !== 'function') { var expect = require('expect.js'); }
 define([
   'app/bestPractices'
 ], function(answers) {
+  var global = typeof window !== 'undefined' ? window :
+               typeof global !== 'undefined' ? global :
+               (function(){ return this; })(); // will not work in strict mode
+
   describe('best practices', function(){
     it('you should avoid global variables', function() {
       answers.globals();
-      expect(window.myObject).not.to.be.ok;
+      expect(global.myObject).not.to.be.ok;
     });
 
     it('you should declare functions safely', function() {

--- a/tests/app/logicalOperators.js
+++ b/tests/app/logicalOperators.js
@@ -11,7 +11,7 @@ define([
       expect(answers.or(true, false)).to.be.ok;
       expect(answers.or(true, true)).to.be.ok;
       expect(answers.or(false, false)).not.to.be.ok;
-      expect(answers.or(3, 4)).to.not.eq(7);
+      expect(answers.or(3, 4)).to.not.eql(7);
     });
       
     it('you should be able to work with logical and', function() {

--- a/tests/app/recursion.js
+++ b/tests/app/recursion.js
@@ -84,11 +84,11 @@ define([
 
     it('you should be able to return the permutations of an array', function() {
       var result = answers.permute(arr);
-      var resultStrings = _.map(result, function(r) { return r.join(''); });
+      var resultStrings = result.map(function(r) { return r.join(''); });
 
       expect(result.length).to.eql(answer.length);
 
-      _.each(answer, function(a) {
+      answer.forEach(function(a) {
         expect(resultStrings.indexOf(a.join('')) > -1).to.be.ok;
       });
     });
@@ -103,7 +103,7 @@ define([
       var result = answers.validParentheses(3);
 
       expect(result.length).to.eql(5);
-      _.each(expected, function(c) {
+      expected.forEach(function(c) {
         expect(result).to.contain(c);
       });
     });


### PR DESCRIPTION
1. In bestPractices.js now uses or window, or global (if in node.js),
   or (function() { return this; })()
   (that should return global in non-strict mode)
2. In logicalOperators.js .eql used instead of .eq,
   because somewhy under node.js there is no such function.
3. In recursion.js _.map(x and _.each(x replaced by
   x.map and x.forEach respectively