### PR TITLE
Prevent library from being published to npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,6 @@
   },
   "bugs": {
     "url": "https://github.com/rmurphey/js-assessment/issues"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
`js-assessment` isn't published on npm, and I think this might be because folks thought it didn't make much sense to publish it there. I prob. agree with that sentiment. To prevent accidental publication, we can add [`private: true`](https://docs.npmjs.com/files/package.json#private) to the manifest, which is what this PR does.