### PR TITLE
Make count.js test less brittle

### DIFF
--- a/tests/app/count.js
+++ b/tests/app/count.js
@@ -43,7 +43,7 @@ define([
       setTimeout(function () {
         expect(nums.length > 1).to.be.ok;
         expect(nums.length < 5).to.be.ok;
-      }, 200);
+      }, 250);
 
       setTimeout(function () {
         expect(nums.length).to.eql(5);


### PR DESCRIPTION
If you set your interval to 100 as the problem prompts, then at exactly 200, it's very likely that you will still have exactly 1 item in `nums` when the expectation is evaluated. Bump the test timeout to 250, and the behavior is much more deterministic.