### PR TITLE
Disallow user returning result rather than expression for logicalOperators.js

### DIFF
--- a/tests/app/logicalOperators.js
+++ b/tests/app/logicalOperators.js
@@ -8,16 +8,20 @@ define([
 ], function(answers) {
   describe('logical operators', function(){
     it('you should be able to work with logical or', function() {
+      expect(answers.or(false, true)).to.be.ok;
       expect(answers.or(true, false)).to.be.ok;
       expect(answers.or(true, true)).to.be.ok;
       expect(answers.or(false, false)).not.to.be.ok;
+      // the following assertion checks for bitwise operator
       expect(answers.or(3, 4)).to.not.eq(7);
     });
-      
+
     it('you should be able to work with logical and', function() {
-      expect(answers.and(false, false)).not.to.be.ok;
+      expect(answers.and(false, true)).not.to.be.ok;
       expect(answers.and(true, false)).not.to.be.ok;
       expect(answers.and(true, true)).to.be.ok;
+      expect(answers.and(false, false)).not.to.be.ok;
+      // the following assertion checks for bitwise operator
       expect(answers.and(3, 4)).to.be.ok;
     });
   });


### PR DESCRIPTION
I'd like to resolve #62 with this commit. Per @PAkerstrand's provided solution, this commit disallows a user from returning the result of a logical operator rather than the operation expression itself.