### PR TITLE
Consistency in arguments on findAllOccurrences in arrays

### DIFF
--- a/tests/app/arrays.js
+++ b/tests/app/arrays.js
@@ -104,7 +104,7 @@ describe('arrays', function() {
   });
 
   it('you should be able to find all occurrences of an item in an array', function() {
-    var result = arraysAnswers.findAllOccurrences('abcdefabc'.split(''), 'a');
+    var result = arraysAnswers.findAllOccurrences([ 1, 2, 3, 4, 5, 6, 1, 7], 1);
 
     expect(result.sort().join(' ')).to.eql('0 6');
   });


### PR DESCRIPTION
While going through the assessment, I was a bit confused that this test case (Arrays: findAllOccurrences() ) used a string to test arrays. It's not functionally different (test case validation works both ways, array form or string form), but I thought I'd write a version that's more internally consistent with js-assessment, and, use an array.