### PR TITLE
Add file watch and live reload with Browsersync

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -1,8 +1,7 @@
 To work on the tests, open a browser and visit http://{{host}}:{{port}}.
 
 The tests are in files in the tests/app directory; you will need to fill out
-the answers in the corresponding files in the app directory, reloading your
-browser to see whether the tests are passing.
+the answers in the corresponding files in the app directory, your browser will reload when you save the files.
 
 For some tests, the instructions will be more involved; in those cases, the
 inline comments should give you the details you need.

--- a/index.js
+++ b/index.js
@@ -1,17 +1,23 @@
 const fs = require('fs');
-const http = require('http');
-const finalHandler = require('finalhandler')
-const serveStatic = require('serve-static');
+const browserSync = require('browser-sync').create();
 
 const port = process.env.PORT || '4444';
 const host = process.env.HOST || '127.0.0.1';
 
-var serve = serveStatic(__dirname, {'index': ['tests/runner.html']})
-
-http.createServer(function (req, res) {
-  done = finalHandler(req, res);
-  serve(req, res, done);
-}).listen(port, host);
+browserSync.init({
+  server: {
+    baseDir: __dirname,
+    index: 'tests/runner.html'
+  },
+  files: ['app/**/*.js'],
+  host: host,
+  port: port,
+  open: false,
+  notify: false,
+  ui: false,
+  ghostMode: false,
+  logLevel: 'silent'
+});
 
 f= fs.readFileSync(__dirname + '/help.txt', 'utf8');
 console.log(f.replace('{{host}}', host).replace('{{port}}', port));

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "backbone": "^1.1.2",
+    "browser-sync": "^2.8.2",
     "chai": "^2.3.0",
     "expect.js": "0.1.2",
-    "finalhandler": "^0.3.5",
     "grunt": "0.4.0",
     "grunt-contrib-connect": "^0.10.1",
     "grunt-contrib-jshint": "~0.1.0",
@@ -23,7 +23,6 @@
     "jquery": "^1.11.0",
     "load-grunt-tasks": "^3.1.0",
     "mocha": "^2.2.4",
-    "serve-static": "^1.9.2",
     "sinon": "^1.14.1",
     "underscore": "1.8.x"
   },


### PR DESCRIPTION
Hey there,

first off thanks for creating / maintaining this project. It's quite interesting :)

Here's a small PR to live-reload the browser when working on the exercises. I think that it can be helpful in order to reduce the back and forth between the editor and the test results.

This is done by replacing `finalhandler` and `serve-static` with Browsersync (http://www.browsersync.io). It serves the files, and also takes care of watching `app/**/*.js` and injecting a live-reload script into the test runner.

If there's interest, we could go a little bit further (either in this PR or in another one):

- Enable automatic opening of the tests in the browser when the project is started (this is just Browsersync configuration).
- Replace the grunt connect/watch tooling with this too.