### PR TITLE
JSHint fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 npm-debug.log
 node_modules/
+*.sublime-*

--- a/.jshintrc
+++ b/.jshintrc
@@ -21,24 +21,5 @@
   "undef": true,
   "sub": true,
   "strict": false,
-  "quotmark": "single",
-
-  "predef": [
-    "describe",
-    "beforeEach",
-    "afterEach",
-    "it",
-    "arraysAnswers",
-    "asyncAnswers",
-    "bestPracticesAnswers",
-    "countAnswers",
-    "flowControlAnswers",
-    "functionsAnswers",
-    "logicalOperatorsAnswers",
-    "modulesAnswers",
-    "numbersAnswers",
-    "objectsAnswers",
-    "recursionAnswers",
-    "regexAnswers"
-  ]
+  "quotmark": "single"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.3.1
+
+- Updated grunt-contrib-jshint to latest version to get latest version of jshint(supports mocha environment and multiple .jshintrc and config extension)
+- Updated jshint configs to prevent errors for unit test source files and be more strict about when unit test syntax and globals are allowed
+- Updated unit test files to set required answers as a local variable to remove dependency on using "predef" property in .jshintrc and manually mantaining list
+
 ## 0.3.0
 
 - Remove jquery, backbone, underscore, mocha, and chai as local libraries

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,7 @@ module.exports = function(grunt) {
         '!app/bestPractices.js'
       ],
       options: {
-        jshintrc: '.jshintrc'
+        jshintrc: true
       }
     },
     watch: {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Rebecca Murphey <rmurphey@gmail.com> (http://rmurphey.com)",
   "name": "js-assessment",
   "description": "A test-driven assessment of JavaScript skills",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "http://rmurphey.com",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
     "finalhandler": "^0.3.5",
     "grunt": "0.4.0",
     "grunt-contrib-connect": "^0.10.1",
-    "grunt-contrib-jshint": "~0.1.0",
+    "grunt-contrib-jshint": "~0.11.2",
     "grunt-contrib-watch": "~0.4.4",
     "jquery": "^1.11.0",
     "load-grunt-tasks": "^3.1.0",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -1,0 +1,7 @@
+{
+  "extends": "../.jshintrc",
+
+  "mocha": true,
+
+  "expr": true
+}

--- a/tests/app/arrays.js
+++ b/tests/app/arrays.js
@@ -1,5 +1,5 @@
 if ( typeof window === 'undefined' ) {
-  require('../../app/arrays');
+  var arraysAnswers = require('../../app/arrays');
   var expect = require('chai').expect;
 }
 

--- a/tests/app/async.js
+++ b/tests/app/async.js
@@ -1,5 +1,5 @@
 if ( typeof window === 'undefined' ) {
-  require('../../app/async');
+  var asyncAnswers = require('../../app/async');
   var expect = require('chai').expect;
 }
 

--- a/tests/app/bestPractices.js
+++ b/tests/app/bestPractices.js
@@ -1,5 +1,5 @@
 if ( typeof window === 'undefined' ) {
-  require('../../app/bestPractices');
+  var bestPracticesAnswers = require('../../app/bestPractices');
   var expect = require('chai').expect;
 }
 

--- a/tests/app/count.js
+++ b/tests/app/count.js
@@ -1,5 +1,5 @@
 if ( typeof window === 'undefined' ) {
-  require('../../app/count');
+  var countAnswers = require('../../app/count');
   var expect = require('chai').expect;
   var sinon = require('sinon');
 }

--- a/tests/app/flowControl.js
+++ b/tests/app/flowControl.js
@@ -1,5 +1,5 @@
 if ( typeof window === 'undefined' ) {
-  require('../../app/flowControl');
+  var flowControlAnswers = require('../../app/flowControl');
   var expect = require('chai').expect;
 }
 

--- a/tests/app/functions.js
+++ b/tests/app/functions.js
@@ -1,5 +1,5 @@
 if ( typeof window === 'undefined' ) {
-  require('../../app/functions');
+  var functionsAnswers = require('../../app/functions');
   var expect = require('chai').expect;
 }
 

--- a/tests/app/logicalOperators.js
+++ b/tests/app/logicalOperators.js
@@ -1,5 +1,5 @@
 if ( typeof window === 'undefined' ) {
-  require('../../app/logicalOperators');
+  var logicalOperatorsAnswers = require('../../app/logicalOperators');
   var expect = require('chai').expect;
 }
 

--- a/tests/app/modules.js
+++ b/tests/app/modules.js
@@ -1,5 +1,5 @@
 if ( typeof window === 'undefined' ) {
-  require('../../app/modules');
+  var modulesAnswers = require('../../app/modules');
   var expect = require('chai').expect;
 }
 

--- a/tests/app/numbers.js
+++ b/tests/app/numbers.js
@@ -1,5 +1,5 @@
 if ( typeof window === 'undefined' ) {
-  require('../../app/numbers');
+  var numbersAnswers = require('../../app/numbers');
   var expect = require('chai').expect;
 }
 

--- a/tests/app/objects.js
+++ b/tests/app/objects.js
@@ -1,5 +1,5 @@
 if ( typeof window === 'undefined' ) {
-  require('../../app/objects');
+  var objectsAnswers = require('../../app/objects');
   var expect = require('chai').expect;
 }
 

--- a/tests/app/recursion.js
+++ b/tests/app/recursion.js
@@ -1,5 +1,5 @@
 if ( typeof window === 'undefined' ) {
-  require('../../app/recursion');
+  var recursionAnswers = require('../../app/recursion');
   var expect = require('chai').expect;
   var _ = require('underscore');
 }

--- a/tests/app/regex.js
+++ b/tests/app/regex.js
@@ -1,5 +1,5 @@
 if ( typeof window === 'undefined' ) {
-  require('../../app/regex');
+  var regexAnswers = require('../../app/regex');
   var expect = require('chai').expect;
 }
 


### PR DESCRIPTION
Updated grunt-contrib-jshint to latest version to get latest version of jshint(supports mocha environment and multiple .jshintrc and config extension).

Updated jshint configs to prevent errors for unit test source files and be more strict about when unit test syntax and globals are allowed.

Updated unit test files to set required answers as a local variable to remove dependency on using "predef" property in .jshintrc and manually mantaining list.