### PR TITLE
add another test expectation to regex USD problem

### DIFF
--- a/app/regex.js
+++ b/app/regex.js
@@ -20,6 +20,7 @@ exports.regexAnswers = {
   matchesPattern : function(str) {
 
   },
+
   isUSD : function(str) {
 
   }

--- a/tests/app/regex.js
+++ b/tests/app/regex.js
@@ -58,5 +58,6 @@ describe('regular expressions', function() {
     expect(regexAnswers.isUSD('$3,432,12.12')).to.eql(false);
     expect(regexAnswers.isUSD('$3,432,1,034.12')).to.eql(false);
     expect(regexAnswers.isUSD('4$3,432,034.12')).to.eql(false);
+    expect(regexAnswers.isUSD('$2.03.45')).to.eql(false);
   });
 });


### PR DESCRIPTION
The given solution is: `/^\$\d{1,3}(,\d{3})*(\.\d{2})?$/`

This new test expectation is intended to enforce the proper use of a `?` at the
second-to-last character in the regex, as opposed to a `*`, which -
although erroneous - currently passes all current test examples.