### PR TITLE
Update recursion.js

### DIFF
--- a/app/recursion.js
+++ b/app/recursion.js
@@ -1,7 +1,7 @@
 exports = (typeof window === 'undefined') ? global : window;
 
 exports.recursionAnswers = {
-  listFiles: function(data, dirName) {
+  listFiles: function(data) {
 
   },
 


### PR DESCRIPTION
dirName parameter is no longer passed in to the unit-test in tests/app/recursion.js
As it is undefined by default, I'm assuming this should simply be removed.